### PR TITLE
Property objects

### DIFF
--- a/src/LesserPhp/Block.php
+++ b/src/LesserPhp/Block.php
@@ -43,7 +43,7 @@ class Block
     public $tags;
 
     /**
-     * @var array
+     * @var Property[]
      */
     public $props = [];
 

--- a/src/LesserPhp/Compiler.php
+++ b/src/LesserPhp/Compiler.php
@@ -512,7 +512,11 @@ class Compiler
                     break;
                 case "import":
                     $id = self::$nextImportId++;
-                    $prop[] = $id;
+
+                    if ($prop instanceof Property\ImportProperty)
+                        $prop->setId($id);
+
+                    //$prop[] = $id;
                     $stack[] = $prop;
                     $imports = array_merge($imports, $stack);
                     $other[] = ["import_mixin", $id];

--- a/src/LesserPhp/Compiler.php
+++ b/src/LesserPhp/Compiler.php
@@ -518,7 +518,7 @@ class Compiler
 
                     $stack[] = $prop;
                     $imports = array_merge($imports, $stack);
-                    $other[] = Property::factoryFromOldFormat($this->parser, ["import_mixin", $id]);
+                    $other[] = Property::factoryFromOldFormat(["import_mixin", $id]);
                     $stack   = [];
                     break;
 

--- a/src/LesserPhp/Compiler.php
+++ b/src/LesserPhp/Compiler.php
@@ -969,147 +969,164 @@ class Compiler
      */
     protected function compileProp($prop, Block $block, $out)
     {
-        // set error position context
-        $this->sourceLoc = isset($prop[-1]) ? $prop[-1] : -1;
+        if ($prop instanceof Property) {
+            $this->sourceLoc = ($prop->hasPos() ? $prop->getPos() : -1);
 
-        switch ($prop[0]) {
-            case 'assign':
-                list(, $name, $value) = $prop;
-                if ($name[0] == $this->vPrefix) {
-                    $this->set($name, $value);
-                } else {
+            switch (true) {
+                case $prop instanceof Property\AssignProperty:
+                    $name = $prop->getName();
+
+                    if ($prop->nameHasPrefix($this->vPrefix)) {
+                        $this->set($name, $prop->getValue());
+
+                        return;
+                    }
+
                     $out->lines[] = $this->formatter->property(
                         $name,
-                        $this->compileValue($this->reduce($value))
+                        $this->compileValue($this->reduce($prop->getValue()))
                     );
-                }
-                break;
-            case 'block':
-                list(, $child) = $prop;
-                $this->compileBlock($child);
-                break;
-            case 'ruleset':
-            case 'mixin':
-                list(, $path, $args, $suffix) = $prop;
 
-                $orderedArgs = [];
-                $keywordArgs = [];
-                foreach ((array)$args as $arg) {
-                    switch ($arg[0]) {
-                        case "arg":
-                            if (!isset($arg[2])) {
-                                $orderedArgs[] = $this->reduce(["variable", $arg[1]]);
-                            } else {
-                                $keywordArgs[$arg[1]] = $this->reduce($arg[2]);
-                            }
-                            break;
+                    return;
 
-                        case "lit":
-                            $orderedArgs[] = $this->reduce($arg[1]);
-                            break;
-                        default:
-                            throw new GeneralException("Unknown arg type: " . $arg[0]);
+                case $prop instanceof Property\BlockProperty:
+                    $this->compileBlock($prop->getChild());
+
+                    return;
+
+                case $prop instanceof Property\RawProperty:
+                    $out->lines[] = $prop->getValue();
+
+                    return;
+
+                case $prop instanceof Property\CommentProperty:
+                    $out->lines[] = $prop->getComment();
+
+                    return;
+
+                case $prop instanceof Property\DirectiveProperty:
+                    $cv           = $this->compileValue($this->reduce($prop->getValue()));
+                    // '@name value;'
+                    $out->lines[] = $this->vPrefix . $prop->getName() . ' ' . $cv . ';';
+
+                    return;
+
+                case $prop instanceof Property\ImportProperty:
+                    $importPath = $this->reduce($prop->getPath());
+                    $result     = $this->tryImport($importPath, $block, $out);
+                    if ($result === false) {
+                        $result = [false, "@import " . $this->compileValue($importPath) . ";"];
                     }
-                }
+                    $this->env->addImports($prop->getId(), $result);
 
-                $mixins = $this->findBlocks($block, $path, $orderedArgs, $keywordArgs);
+                    return;
 
-                if ($mixins === null) {
-                    $block->parser->throwError("{$prop[1][0]} is undefined", $block->count);
-                }
-
-                if (strpos($prop[1][0], "$") === 0) {
-                    //Use Ruleset Logic - Only last element
-                    $mixins = [array_pop($mixins)];
-                }
-
-                foreach ($mixins as $mixin) {
-                    if ($mixin === $block && !$orderedArgs) {
-                        continue;
-                    }
-
-                    $haveScope = false;
-                    if (isset($mixin->parent->scope)) {
-                        $haveScope = true;
-                        $mixinParentEnv = $this->pushEnv($this->env);
-                        $mixinParentEnv->storeParent = $mixin->parent->scope;
+                case $prop instanceof Property\ImportMixinProperty:
+                    $import = $this->env->getImports($prop->getId());
+                    if ($import[0] === false) {
+                        if (isset($import[1])) {
+                            $out->lines[] = $import[1];
+                        }
+                    } else {
+                        $bottom    = $import[1];
+                        $importDir = $import[3];
+                        $this->compileImportedProps($bottom, $block, $out, $importDir);
                     }
 
-                    $haveArgs = false;
-                    if (isset($mixin->args)) {
-                        $haveArgs = true;
-                        $this->pushEnv($this->env);
-                        $this->zipSetArgs($mixin->args, $orderedArgs, $keywordArgs);
+                    return;
+
+                case $prop instanceof Property\RulesetProperty:
+                case $prop instanceof Property\MixinProperty:
+                    $path=$prop->getPath();
+                    $args = $prop->getArgs();
+                    $suffix=$prop->getSuffix();
+
+                    $orderedArgs = [];
+                    $keywordArgs = [];
+                    foreach ($args as $arg) {
+                        switch ($arg[0]) {
+                            case "arg":
+                                if (!isset($arg[2])) {
+                                    $orderedArgs[] = $this->reduce(["variable", $arg[1]]);
+                                } else {
+                                    $keywordArgs[$arg[1]] = $this->reduce($arg[2]);
+                                }
+                                break;
+
+                            case "lit":
+                                $orderedArgs[] = $this->reduce($arg[1]);
+                                break;
+                            default:
+                                throw new GeneralException("Unknown arg type: " . $arg[0]);
+                        }
                     }
 
-                    $oldParent = $mixin->parent;
-                    if ($mixin != $block) {
-                        $mixin->parent = $block;
+                    $mixins = $this->findBlocks($block, $path, $orderedArgs, $keywordArgs);
+
+                    if ($mixins === null) {
+                        $block->parser->throwError("{$prop[1][0]} is undefined", $block->count);
                     }
 
-                    foreach ($this->sortProps($mixin->props) as $subProp) {
-                        if ($suffix !== null &&
-                            $subProp[0] === "assign" &&
-                            is_string($subProp[1]) &&
-                            $subProp[1]{0} != $this->vPrefix
-                        ) {
-                            $subProp[2] = [
-                                'list',
-                                ' ',
-                                [$subProp[2], ['keyword', $suffix]],
-                            ];
+                    if (strpos($path[0], "$") === 0) {
+                        //Use Ruleset Logic - Only last element
+                        $mixins = [array_pop($mixins)];
+                    }
+
+                    foreach ($mixins as $mixin) {
+                        if ($mixin === $block && !$orderedArgs) {
+                            continue;
                         }
 
-                        $this->compileProp($subProp, $mixin, $out);
+                        $haveScope = false;
+                        if (isset($mixin->parent->scope)) {
+                            $haveScope = true;
+                            $mixinParentEnv = $this->pushEnv($this->env);
+                            $mixinParentEnv->storeParent = $mixin->parent->scope;
+                        }
+
+                        $haveArgs = false;
+                        if (isset($mixin->args)) {
+                            $haveArgs = true;
+                            $this->pushEnv($this->env);
+                            $this->zipSetArgs($mixin->args, $orderedArgs, $keywordArgs);
+                        }
+
+                        $oldParent = $mixin->parent;
+                        if ($mixin != $block) {
+                            $mixin->parent = $block;
+                        }
+
+                        foreach ($this->sortProps($mixin->props) as $subProp) {
+                            /** @var Property $subProp */
+                            if ($suffix !== null &&
+                                $subProp instanceof Property\AssignProperty &&
+                                !$subProp->nameHasPrefix($this->vPrefix)
+                            ) {
+                                $subProp[2] = ['list', ' ', [$subProp[2], ['keyword', $suffix]]];
+                            }
+
+                            $this->compileProp($subProp, $mixin, $out);
+                        }
+
+                        $mixin->parent = $oldParent;
+
+                        if ($haveArgs) {
+                            $this->popEnv();
+                        }
+                        if ($haveScope) {
+                            $this->popEnv();
+                        }
                     }
 
-                    $mixin->parent = $oldParent;
+                   return;
 
-                    if ($haveArgs) {
-                        $this->popEnv();
-                    }
-                    if ($haveScope) {
-                        $this->popEnv();
-                    }
-                }
-
-                break;
-            case 'raw':
-                $out->lines[] = $prop[1];
-                break;
-            case "directive":
-                list(, $name, $value) = $prop;
-                $out->lines[] = "@$name " . $this->compileValue($this->reduce($value)) . ';';
-                break;
-            case "comment":
-                $out->lines[] = $prop[1];
-                break;
-            case "import":
-                list(, $importPath, $importId) = $prop;
-                $importPath = $this->reduce($importPath);
-
-                $result = $this->tryImport($importPath, $block, $out);
-
-                $this->env->addImports($importId, $result === false ?
-                    [false, "@import " . $this->compileValue($importPath) . ";"] :
-                    $result);
-
-                break;
-            case "import_mixin":
-                list(, $importId) = $prop;
-                $import = $this->env->getImports($importId);
-                if ($import[0] === false) {
-                    if (isset($import[1])) {
-                        $out->lines[] = $import[1];
-                    }
-                } else {
-                    list(, $bottom, $parser, $importDir) = $import;
-                    $this->compileImportedProps($bottom, $block, $out, $importDir);
-                }
-
-                break;
-            default:
-                $block->parser->throwError("unknown op: {$prop[0]}\n", $block->count);
+                default:
+                    $block->parser->throwError("unknown op: {$prop[0]}\n", $block->count);
+            }
+        } else {
+            $property = Property::factoryFromOldFormat($this->parser, $prop);
+            $this->compileProp($property, $block, $out);
+            return;
         }
     }
 

--- a/src/LesserPhp/Compiler.php
+++ b/src/LesserPhp/Compiler.php
@@ -203,14 +203,14 @@ class Compiler
     }
 
     /**
-     * @param array $importPath
-     * @param       $parentBlock
-     * @param       $out
+     * @param array     $importPath
+     * @param Block     $parentBlock
+     * @param \stdClass $out
      *
      * @return array|false
      * @throws \LesserPhp\Exception\GeneralException
      */
-    protected function tryImport(array $importPath, $parentBlock, $out)
+    protected function tryImport(array $importPath, Block $parentBlock, \stdClass $out)
     {
         if ($importPath[0] === 'function' && $importPath[1] === 'url') {
             $importPath = $this->flattenList($importPath[2]);
@@ -248,8 +248,8 @@ class Compiler
 
         // set the parents of all the block props
         foreach ($root->props as $prop) {
-            if ($prop[0] === 'block') {
-                $prop[1]->parent = $parentBlock;
+            if ($prop instanceof Property\BlockProperty) {
+                $prop->getChild()->parent = $parentBlock;
             }
         }
 
@@ -441,12 +441,12 @@ class Compiler
     }
 
     /**
-     * @param Block $block
+     * @param Block     $block
      * @param \stdClass $out
      *
      * @throws \LesserPhp\Exception\GeneralException
      */
-    protected function compileProps(Block $block, $out)
+    protected function compileProps(Block $block, \stdClass $out)
     {
         foreach ($this->sortProps($block->props) as $prop) {
             $this->compileProp($prop, $block, $out);
@@ -1064,7 +1064,7 @@ class Compiler
                 $mixins = $this->findBlocks($block, $path, $orderedArgs, $keywordArgs);
 
                 if ($mixins === null) {
-                    $block->parser->throwError("{$prop[1][0]} is undefined", $block->count);
+                    $block->parser->throwError($prop->getPath()[0].' is undefined', $block->count);
                 }
 
                 if (strpos($path[0], "$") === 0) {
@@ -1102,7 +1102,7 @@ class Compiler
                             $subProp instanceof Property\AssignProperty &&
                             !$subProp->nameHasPrefix($this->vPrefix)
                         ) {
-                            $subProp[2] = ['list', ' ', [$subProp[2], ['keyword', $suffix]]];
+                            $subProp->setValue(['list', ' ', [$subProp->getValue(), ['keyword', $suffix]]]);
                         }
 
                         $this->compileProp($subProp, $mixin, $out);
@@ -1121,7 +1121,7 @@ class Compiler
                 return;
 
             default:
-                $block->parser->throwError("unknown op: {$prop[0]}\n", $block->count);
+                $block->parser->throwError("unknown op: {$prop->getType()}\n", $block->count);
         }
     }
 

--- a/src/LesserPhp/Parser.php
+++ b/src/LesserPhp/Parser.php
@@ -83,7 +83,7 @@ class Parser
     /** @var string */
     public $buffer;
 
-    /** @var mixed $env Block Stack */
+    /** @var Block|null $env Block Stack */
     private $env;
     /** @var bool */
     private $inExp;
@@ -1795,13 +1795,45 @@ nav ul {
         if ($pos !== null) {
             $prop[-1] = $pos;
         }
-        $this->env->props[] = $prop;
+
+
+        /*
+         * A property array looks like this:
+         * [-1] => optional position
+         * [0]  => type
+         * [1]  => value
+         * [2]  => optional more information
+         * [3]  => optional more information
+         *
+         * 0 and 1 are always present
+         * only comments have the simplest form with only 1 value
+         */
+
+        if (!isset($prop[0], $prop[1])) {
+            throw new \UnexpectedValueException('Too few property information given.');
+        }
+
+        $type   = $prop[0];
+        $value1 = $prop[1];
+        $value2 = null;
+        $value3 = null;
+
+        if (isset($prop[2])) {
+            $value2 = $prop[2];
+        }
+        if (isset($prop[3])) {
+            $value3 = $prop[3];
+        }
+
+        $property = Property::factory($this, $type, $pos, $value1, $value2, $value3);
+
+        $this->env->props[] = $property;
     }
 
     /**
      * pop something off the stack
      *
-     * @return mixed
+     * @return Block
      */
     protected function pop()
     {

--- a/src/LesserPhp/Parser.php
+++ b/src/LesserPhp/Parser.php
@@ -1796,36 +1796,7 @@ nav ul {
             $prop[-1] = $pos;
         }
 
-
-        /*
-         * A property array looks like this:
-         * [-1] => optional position
-         * [0]  => type
-         * [1]  => value
-         * [2]  => optional more information
-         * [3]  => optional more information
-         *
-         * 0 and 1 are always present
-         * only comments have the simplest form with only 1 value
-         */
-
-        if (!isset($prop[0], $prop[1])) {
-            throw new \UnexpectedValueException('Too few property information given.');
-        }
-
-        $type   = $prop[0];
-        $value1 = $prop[1];
-        $value2 = null;
-        $value3 = null;
-
-        if (isset($prop[2])) {
-            $value2 = $prop[2];
-        }
-        if (isset($prop[3])) {
-            $value3 = $prop[3];
-        }
-
-        $property = Property::factory($this, $type, $pos, $value1, $value2, $value3);
+        $property = Property::factoryFromOldFormat($this, $prop, $pos);
 
         $this->env->props[] = $property;
     }

--- a/src/LesserPhp/Parser.php
+++ b/src/LesserPhp/Parser.php
@@ -1796,7 +1796,7 @@ nav ul {
             $prop[-1] = $pos;
         }
 
-        $property = Property::factoryFromOldFormat($this, $prop, $pos);
+        $property = Property::factoryFromOldFormat($prop, $pos);
 
         $this->env->props[] = $property;
     }

--- a/src/LesserPhp/Property.php
+++ b/src/LesserPhp/Property.php
@@ -76,9 +76,17 @@ abstract class Property implements \ArrayAccess
     }
 
     /**
+     * @return bool
+     */
+    public function hasPos()
+    {
+        return ($this->pos !== null);
+    }
+
+    /**
      * @return mixed
      */
-    public function getValue1()
+    protected function getValue1()
     {
         return $this->value1;
     }
@@ -86,7 +94,7 @@ abstract class Property implements \ArrayAccess
     /**
      * @param mixed $value
      */
-    public function setValue1($value)
+    protected function setValue1($value)
     {
         $this->value1 = $value;
     }
@@ -94,7 +102,7 @@ abstract class Property implements \ArrayAccess
     /**
      * @return mixed
      */
-    public function getValue2()
+    protected function getValue2()
     {
         return $this->value2;
     }
@@ -102,7 +110,7 @@ abstract class Property implements \ArrayAccess
     /**
      * @param mixed $value
      */
-    public function setValue2($value)
+    protected function setValue2($value)
     {
         $this->value2 = $value;
     }
@@ -110,7 +118,7 @@ abstract class Property implements \ArrayAccess
     /**
      * @return mixed
      */
-    public function getValue3()
+    protected function getValue3()
     {
         return $this->value3;
     }
@@ -118,7 +126,7 @@ abstract class Property implements \ArrayAccess
     /**
      * @param mixed $value
      */
-    public function setValue3($value)
+    protected function setValue3($value)
     {
         $this->value3 = $value;
     }
@@ -183,6 +191,7 @@ abstract class Property implements \ArrayAccess
      */
     public static function factory(Parser $parser, $type, $pos, $value1, $value2 = null, $value3 = null)
     {
+        $type = implode('', array_map('ucfirst', explode('_', $type)));
         $className = __NAMESPACE__ . '\Property\\' . ucfirst($type) . 'Property';
 
         if (!class_exists($className)) {
@@ -198,5 +207,38 @@ abstract class Property implements \ArrayAccess
         $property->setValue3($value3);
 
         return $property;
+    }
+
+    public static function factoryFromOldFormat(Parser $parser, array $prop, $pos = null)
+    {
+        /*
+         * A property array looks like this:
+         * [-1] => optional position
+         * [0]  => type
+         * [1]  => value
+         * [2]  => optional more information
+         * [3]  => optional more information
+         *
+         * 0 and 1 are always present
+         * only comments have the simplest form with only 1 value
+         */
+
+        if (!isset($prop[0], $prop[1])) {
+            throw new \UnexpectedValueException('Too few property information given.');
+        }
+
+        $type   = $prop[0];
+        $value1 = $prop[1];
+        $value2 = null;
+        $value3 = null;
+
+        if (isset($prop[2])) {
+            $value2 = $prop[2];
+        }
+        if (isset($prop[3])) {
+            $value3 = $prop[3];
+        }
+
+        return self::factory($parser, $type, $pos, $value1, $value2, $value3);
     }
 }

--- a/src/LesserPhp/Property.php
+++ b/src/LesserPhp/Property.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace LesserPhp;
+
+/**
+ * lesserphp
+ * https://www.maswaba.de/lesserphp
+ *
+ * LESS CSS compiler, adapted from http://lesscss.org
+ *
+ * Copyright 2013, Leaf Corcoran <leafot@gmail.com>
+ * Copyright 2016, Marcus Schwarz <github@maswaba.de>
+ * Copyright 2017, Stefan Pöhner <github@poe-php.de>
+ * Licensed under MIT or GPLv3, see LICENSE
+ *
+ * @author  Stefan Pöhner <github@poe-php.de>
+ *
+ * @package LesserPhp
+ */
+
+abstract class Property implements \ArrayAccess
+{
+    /**
+     * @var Parser
+     */
+    protected $parser;
+
+    /**
+     * @var int|null
+     */
+    protected $pos;
+
+    /**
+     * @var mixed
+     */
+    protected $value1;
+
+    /**
+     * @var mixed
+     */
+    protected $value2;
+
+    /**
+     * @var mixed
+     */
+    protected $value3;
+
+    /**
+     * Property constructor.
+     *
+     * @param Parser   $parser
+     * @param int|null $pos
+     * @param mixed    $value1
+     */
+    public function __construct(Parser $parser, $pos, $value1)
+    {
+        $this->parser = $parser;
+        $this->pos    = $pos;
+        $this->value1 = $value1;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return strtolower(str_replace([__NAMESPACE__.'\\', '\\', 'Property'], '', get_class($this)));
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPos()
+    {
+        return $this->pos;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue1()
+    {
+        return $this->value1;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue1($value)
+    {
+        $this->value1 = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue2()
+    {
+        return $this->value2;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue2($value)
+    {
+        $this->value2 = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue3()
+    {
+        return $this->value3;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue3($value)
+    {
+        $this->value3 = $value;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetExists($offset)
+    {
+        return (is_int($offset) && $offset >= -1 && $offset <= 3);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetGet($offset)
+    {
+        if ($offset === -1) {
+            return $this->getPos();
+        } elseif ($offset === 0) {
+            return $this->getType();
+        } elseif ($offset === 1) {
+            return $this->getValue1();
+        } elseif ($offset === 2) {
+            return $this->getValue2();
+        } elseif ($offset === 3) {
+            return $this->getValue3();
+        } else {
+            throw new \InvalidArgumentException("Unknown offset $offset");
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetSet($offset, $value)
+    {
+        // this only happens for sub-properties
+        if ($offset === 2) {
+            return $this->setValue2($value);
+        } else {
+            throw new \InvalidArgumentException("Unknown offset $offset");
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetUnset($offset)
+    {
+    }
+
+    /**
+     * @param Parser     $parser
+     * @param string     $type
+     * @param int|null   $pos
+     * @param mixed      $value1
+     * @param mixed|null $value2
+     * @param mixed|null $value3
+     *
+     * @return self
+     */
+    public static function factory(Parser $parser, $type, $pos, $value1, $value2 = null, $value3 = null)
+    {
+        $className = __NAMESPACE__ . '\Property\\' . ucfirst($type) . 'Property';
+
+        if (!class_exists($className)) {
+            throw new \UnexpectedValueException("Unknown property type: $type");
+        }
+
+        $property = new $className($parser, $pos, $value1);
+        if (!$property instanceof self) {
+            throw new \RuntimeException("$className must extend " . self::class);
+        }
+
+        $property->setValue2($value2);
+        $property->setValue3($value3);
+
+        return $property;
+    }
+}

--- a/src/LesserPhp/Property.php
+++ b/src/LesserPhp/Property.php
@@ -136,7 +136,7 @@ abstract class Property implements \ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return (is_int($offset) && $offset >= -1 && $offset <= 3);
+        throw new \RuntimeException('Array access is deprecated! ');
     }
 
     /**
@@ -144,19 +144,7 @@ abstract class Property implements \ArrayAccess
      */
     public function offsetGet($offset)
     {
-        if ($offset === -1) {
-            return $this->getPos();
-        } elseif ($offset === 0) {
-            return $this->getType();
-        } elseif ($offset === 1) {
-            return $this->getValue1();
-        } elseif ($offset === 2) {
-            return $this->getValue2();
-        } elseif ($offset === 3) {
-            return $this->getValue3();
-        } else {
-            throw new \InvalidArgumentException("Unknown offset $offset");
-        }
+        throw new \RuntimeException('Array access is deprecated! ');
     }
 
     /**
@@ -164,12 +152,7 @@ abstract class Property implements \ArrayAccess
      */
     public function offsetSet($offset, $value)
     {
-        // this only happens for sub-properties
-        if ($offset === 2) {
-            return $this->setValue2($value);
-        } else {
-            throw new \InvalidArgumentException("Unknown offset $offset");
-        }
+        throw new \RuntimeException('Array access is deprecated! ');
     }
 
     /**
@@ -177,6 +160,7 @@ abstract class Property implements \ArrayAccess
      */
     public function offsetUnset($offset)
     {
+        throw new \RuntimeException('Array access is deprecated! ');
     }
 
     /**

--- a/src/LesserPhp/Property.php
+++ b/src/LesserPhp/Property.php
@@ -48,13 +48,11 @@ abstract class Property implements \ArrayAccess
     /**
      * Property constructor.
      *
-     * @param Parser   $parser
      * @param int|null $pos
      * @param mixed    $value1
      */
-    public function __construct(Parser $parser, $pos, $value1)
+    public function __construct($pos, $value1)
     {
-        $this->parser = $parser;
         $this->pos    = $pos;
         $this->value1 = $value1;
     }
@@ -64,7 +62,7 @@ abstract class Property implements \ArrayAccess
      */
     public function getType()
     {
-        return strtolower(str_replace([__NAMESPACE__.'\\', '\\', 'Property'], '', get_class($this)));
+        return strtolower(str_replace([__NAMESPACE__ . '\\', '\\', 'Property'], '', get_class($this)));
     }
 
     /**
@@ -164,7 +162,6 @@ abstract class Property implements \ArrayAccess
     }
 
     /**
-     * @param Parser     $parser
      * @param string     $type
      * @param int|null   $pos
      * @param mixed      $value1
@@ -173,16 +170,16 @@ abstract class Property implements \ArrayAccess
      *
      * @return self
      */
-    public static function factory(Parser $parser, $type, $pos, $value1, $value2 = null, $value3 = null)
+    public static function factory($type, $pos, $value1, $value2 = null, $value3 = null)
     {
-        $type = implode('', array_map('ucfirst', explode('_', $type)));
+        $type      = implode('', array_map('ucfirst', explode('_', $type)));
         $className = __NAMESPACE__ . '\Property\\' . ucfirst($type) . 'Property';
 
         if (!class_exists($className)) {
             throw new \UnexpectedValueException("Unknown property type: $type");
         }
 
-        $property = new $className($parser, $pos, $value1);
+        $property = new $className($pos, $value1);
         if (!$property instanceof self) {
             throw new \RuntimeException("$className must extend " . self::class);
         }
@@ -193,7 +190,13 @@ abstract class Property implements \ArrayAccess
         return $property;
     }
 
-    public static function factoryFromOldFormat(Parser $parser, array $prop, $pos = null)
+    /**
+     * @param array    $prop
+     * @param int|null $pos
+     *
+     * @return Property
+     */
+    public static function factoryFromOldFormat(array $prop, $pos = null)
     {
         /*
          * A property array looks like this:
@@ -223,6 +226,6 @@ abstract class Property implements \ArrayAccess
             $value3 = $prop[3];
         }
 
-        return self::factory($parser, $type, $pos, $value1, $value2, $value3);
+        return self::factory($type, $pos, $value1, $value2, $value3);
     }
 }

--- a/src/LesserPhp/Property/AssignProperty.php
+++ b/src/LesserPhp/Property/AssignProperty.php
@@ -45,4 +45,12 @@ class AssignProperty extends \LesserPhp\Property
     {
         return $this->getValue2();
     }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue($value)
+    {
+        $this->setValue2($value);
+    }
 }

--- a/src/LesserPhp/Property/AssignProperty.php
+++ b/src/LesserPhp/Property/AssignProperty.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LesserPhp\Property;
+
+/**
+ * lesserphp
+ * https://www.maswaba.de/lesserphp
+ *
+ * LESS CSS compiler, adapted from http://lesscss.org
+ *
+ * Copyright 2013, Leaf Corcoran <leafot@gmail.com>
+ * Copyright 2016, Marcus Schwarz <github@maswaba.de>
+ * Copyright 2017, Stefan Pöhner <github@poe-php.de>
+ * Licensed under MIT or GPLv3, see LICENSE
+ *
+ * @author  Stefan Pöhner <github@poe-php.de>
+ *
+ * @package LesserPhp
+ */
+
+class AssignProperty extends \LesserPhp\Property
+{
+
+}

--- a/src/LesserPhp/Property/AssignProperty.php
+++ b/src/LesserPhp/Property/AssignProperty.php
@@ -20,5 +20,29 @@ namespace LesserPhp\Property;
 
 class AssignProperty extends \LesserPhp\Property
 {
+    /**
+     * @param string $prefixToCheck Single character to check.
+     *
+     * @return bool
+     */
+    public function nameHasPrefix($prefixToCheck)
+    {
+        return ($this->getName() && $this->getName()[0] === $prefixToCheck);
+    }
 
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getValue1();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->getValue2();
+    }
 }

--- a/src/LesserPhp/Property/BlockProperty.php
+++ b/src/LesserPhp/Property/BlockProperty.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LesserPhp\Property;
+
+/**
+ * lesserphp
+ * https://www.maswaba.de/lesserphp
+ *
+ * LESS CSS compiler, adapted from http://lesscss.org
+ *
+ * Copyright 2013, Leaf Corcoran <leafot@gmail.com>
+ * Copyright 2016, Marcus Schwarz <github@maswaba.de>
+ * Copyright 2017, Stefan Pöhner <github@poe-php.de>
+ * Licensed under MIT or GPLv3, see LICENSE
+ *
+ * @author  Stefan Pöhner <github@poe-php.de>
+ *
+ * @package LesserPhp
+ */
+
+class BlockProperty extends \LesserPhp\Property
+{
+
+}

--- a/src/LesserPhp/Property/BlockProperty.php
+++ b/src/LesserPhp/Property/BlockProperty.php
@@ -20,5 +20,11 @@ namespace LesserPhp\Property;
 
 class BlockProperty extends \LesserPhp\Property
 {
-
+    /**
+     * @return \LesserPhp\Block
+     */
+    public function getChild()
+    {
+        return $this->getValue1();
+    }
 }

--- a/src/LesserPhp/Property/BlockProperty.php
+++ b/src/LesserPhp/Property/BlockProperty.php
@@ -23,7 +23,7 @@ class BlockProperty extends \LesserPhp\Property
     /**
      * @return \LesserPhp\Block
      */
-    public function getChild()
+    public function getBlock()
     {
         return $this->getValue1();
     }

--- a/src/LesserPhp/Property/CanCompile.php
+++ b/src/LesserPhp/Property/CanCompile.php
@@ -18,23 +18,16 @@ namespace LesserPhp\Property;
  * @package LesserPhp
  */
 
-class RawProperty extends \LesserPhp\Property implements CanCompile
+/**
+ * Interface CanCompile
+ * Implemented by properties, that can compile themselves.
+ */
+interface CanCompile
 {
     /**
+     * @param \LesserPhp\Compiler $compiler
+     *
      * @return mixed
      */
-    public function getValue()
-    {
-        return $this->getValue1();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function compile(\LesserPhp\Compiler $compiler)
-    {
-        unset($compiler);
-
-        return $this->getValue();
-    }
+    public function compile(\LesserPhp\Compiler $compiler);
 }

--- a/src/LesserPhp/Property/CommentProperty.php
+++ b/src/LesserPhp/Property/CommentProperty.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LesserPhp\Property;
+
+/**
+ * lesserphp
+ * https://www.maswaba.de/lesserphp
+ *
+ * LESS CSS compiler, adapted from http://lesscss.org
+ *
+ * Copyright 2013, Leaf Corcoran <leafot@gmail.com>
+ * Copyright 2016, Marcus Schwarz <github@maswaba.de>
+ * Copyright 2017, Stefan Pöhner <github@poe-php.de>
+ * Licensed under MIT or GPLv3, see LICENSE
+ *
+ * @author  Stefan Pöhner <github@poe-php.de>
+ *
+ * @package LesserPhp
+ */
+
+class CommentProperty extends \LesserPhp\Property
+{
+
+}

--- a/src/LesserPhp/Property/CommentProperty.php
+++ b/src/LesserPhp/Property/CommentProperty.php
@@ -20,5 +20,11 @@ namespace LesserPhp\Property;
 
 class CommentProperty extends \LesserPhp\Property
 {
-
+    /**
+     * @return string
+     */
+    public function getComment()
+    {
+        return $this->getValue1();
+    }
 }

--- a/src/LesserPhp/Property/CommentProperty.php
+++ b/src/LesserPhp/Property/CommentProperty.php
@@ -18,7 +18,7 @@ namespace LesserPhp\Property;
  * @package LesserPhp
  */
 
-class CommentProperty extends \LesserPhp\Property
+class CommentProperty extends \LesserPhp\Property implements CanCompile
 {
     /**
      * @return string
@@ -26,5 +26,15 @@ class CommentProperty extends \LesserPhp\Property
     public function getComment()
     {
         return $this->getValue1();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function compile(\LesserPhp\Compiler $compiler)
+    {
+        unset($compiler);
+
+        return $this->getComment();
     }
 }

--- a/src/LesserPhp/Property/DirectiveProperty.php
+++ b/src/LesserPhp/Property/DirectiveProperty.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LesserPhp\Property;
+
+/**
+ * lesserphp
+ * https://www.maswaba.de/lesserphp
+ *
+ * LESS CSS compiler, adapted from http://lesscss.org
+ *
+ * Copyright 2013, Leaf Corcoran <leafot@gmail.com>
+ * Copyright 2016, Marcus Schwarz <github@maswaba.de>
+ * Copyright 2017, Stefan Pöhner <github@poe-php.de>
+ * Licensed under MIT or GPLv3, see LICENSE
+ *
+ * @author  Stefan Pöhner <github@poe-php.de>
+ *
+ * @package LesserPhp
+ */
+
+class DirectiveProperty extends \LesserPhp\Property
+{
+
+}

--- a/src/LesserPhp/Property/DirectiveProperty.php
+++ b/src/LesserPhp/Property/DirectiveProperty.php
@@ -20,5 +20,19 @@ namespace LesserPhp\Property;
 
 class DirectiveProperty extends \LesserPhp\Property
 {
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getValue1();
+    }
 
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->getValue2();
+    }
 }

--- a/src/LesserPhp/Property/DirectiveProperty.php
+++ b/src/LesserPhp/Property/DirectiveProperty.php
@@ -18,7 +18,7 @@ namespace LesserPhp\Property;
  * @package LesserPhp
  */
 
-class DirectiveProperty extends \LesserPhp\Property
+class DirectiveProperty extends \LesserPhp\Property implements CanCompile
 {
     /**
      * @return string
@@ -34,5 +34,16 @@ class DirectiveProperty extends \LesserPhp\Property
     public function getValue()
     {
         return $this->getValue2();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function compile(\LesserPhp\Compiler $compiler)
+    {
+        $cv = $compiler->compileValue($compiler->reduce($this->getValue()));
+
+        // Format: '@name value;'
+        return $compiler->getVPrefix() . $this->getName() . ' ' . $cv . ';';
     }
 }

--- a/src/LesserPhp/Property/ImportMixinProperty.php
+++ b/src/LesserPhp/Property/ImportMixinProperty.php
@@ -18,14 +18,14 @@ namespace LesserPhp\Property;
  * @package LesserPhp
  */
 
-class ImportProperty extends \LesserPhp\Property
+class ImportMixinProperty extends \LesserPhp\Property
 {
     /**
      * @return string
      */
-    public function getPath()
+    public function getType()
     {
-        return $this->getValue1();
+        return 'import_mixin';
     }
 
     /**
@@ -33,14 +33,6 @@ class ImportProperty extends \LesserPhp\Property
      */
     public function getId()
     {
-        return $this->getValue2();
-    }
-
-    /**
-     * @param int $id
-     */
-    public function setId($id)
-    {
-        $this->setValue2($id);
+        return $this->getValue1();
     }
 }

--- a/src/LesserPhp/Property/ImportProperty.php
+++ b/src/LesserPhp/Property/ImportProperty.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LesserPhp\Property;
+
+/**
+ * lesserphp
+ * https://www.maswaba.de/lesserphp
+ *
+ * LESS CSS compiler, adapted from http://lesscss.org
+ *
+ * Copyright 2013, Leaf Corcoran <leafot@gmail.com>
+ * Copyright 2016, Marcus Schwarz <github@maswaba.de>
+ * Copyright 2017, Stefan Pöhner <github@poe-php.de>
+ * Licensed under MIT or GPLv3, see LICENSE
+ *
+ * @author  Stefan Pöhner <github@poe-php.de>
+ *
+ * @package LesserPhp
+ */
+
+class ImportProperty extends \LesserPhp\Property
+{
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->setValue2($id);
+    }
+}

--- a/src/LesserPhp/Property/MixinProperty.php
+++ b/src/LesserPhp/Property/MixinProperty.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LesserPhp\Property;
+
+/**
+ * lesserphp
+ * https://www.maswaba.de/lesserphp
+ *
+ * LESS CSS compiler, adapted from http://lesscss.org
+ *
+ * Copyright 2013, Leaf Corcoran <leafot@gmail.com>
+ * Copyright 2016, Marcus Schwarz <github@maswaba.de>
+ * Copyright 2017, Stefan Pöhner <github@poe-php.de>
+ * Licensed under MIT or GPLv3, see LICENSE
+ *
+ * @author  Stefan Pöhner <github@poe-php.de>
+ *
+ * @package LesserPhp
+ */
+
+class MixinProperty extends \LesserPhp\Property
+{
+
+}

--- a/src/LesserPhp/Property/MixinProperty.php
+++ b/src/LesserPhp/Property/MixinProperty.php
@@ -20,5 +20,27 @@ namespace LesserPhp\Property;
 
 class MixinProperty extends \LesserPhp\Property
 {
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->getValue1();
+    }
 
+    /**
+     * @return array
+     */
+    public function getArgs()
+    {
+        return (array)$this->getValue2();
+    }
+
+    /**
+     * @return string
+     */
+    public function getSuffix()
+    {
+        return $this->getValue3();
+    }
 }

--- a/src/LesserPhp/Property/RawProperty.php
+++ b/src/LesserPhp/Property/RawProperty.php
@@ -18,29 +18,13 @@ namespace LesserPhp\Property;
  * @package LesserPhp
  */
 
-class ImportProperty extends \LesserPhp\Property
+class RawProperty extends \LesserPhp\Property
 {
     /**
-     * @return string
+     * @return mixed
      */
-    public function getPath()
+    public function getValue()
     {
         return $this->getValue1();
-    }
-
-    /**
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->getValue2();
-    }
-
-    /**
-     * @param int $id
-     */
-    public function setId($id)
-    {
-        $this->setValue2($id);
     }
 }

--- a/src/LesserPhp/Property/RulesetProperty.php
+++ b/src/LesserPhp/Property/RulesetProperty.php
@@ -18,29 +18,7 @@ namespace LesserPhp\Property;
  * @package LesserPhp
  */
 
-class ImportProperty extends \LesserPhp\Property
+class RulesetProperty extends MixinProperty
 {
-    /**
-     * @return string
-     */
-    public function getPath()
-    {
-        return $this->getValue1();
-    }
-
-    /**
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->getValue2();
-    }
-
-    /**
-     * @param int $id
-     */
-    public function setId($id)
-    {
-        $this->setValue2($id);
-    }
+    // this is just an alias
 }


### PR DESCRIPTION
Properties are now handled as objects

* There is a factory that does the conversion from the old array format to an object.
* Compilation is moved to the properties themselves - if possible.
Unfortunately the compiler is too much intertwined with everything, so not all properties can do that yet.
* Added proper type hints to alle methods handling properties.
* To help the transition, I kept ArrayAccess for Property, but it throws an Exception.