### PR TITLE
Fix dynamic imports

### DIFF
--- a/src/LesserPhp/Compiler.php
+++ b/src/LesserPhp/Compiler.php
@@ -533,9 +533,9 @@ class Compiler
         $other = array_merge($other, $stack);
 
         if ($split) {
-            return [array_merge($imports, $vars), $other];
+            return [array_merge($vars, $imports, $vars), $other];
         } else {
-            return array_merge($imports, $vars, $other);
+            return array_merge($vars, $imports, $vars, $other);
         }
     }
 

--- a/tests/inputs/import.less
+++ b/tests/inputs/import.less
@@ -51,6 +51,9 @@ div {
 pre {
 	color: @someValue;
 }
+blockquote {
+	color: @someOtherValue;
+}
 
 @import "file3";
-
+@someOtherValue: hello-from-imports-file;

--- a/tests/inputs/import.less
+++ b/tests/inputs/import.less
@@ -57,3 +57,6 @@ blockquote {
 
 @import "file3";
 @someOtherValue: hello-from-imports-file;
+
+@dynamicImport: "file4";
+@import @dynamicImport;

--- a/tests/inputs/test-imports/file3.less
+++ b/tests/inputs/test-imports/file3.less
@@ -4,4 +4,5 @@ h2 {
 }
 
 @someValue: hello-from-file-3;
+@someOtherValue: hello-from-file-3;
 

--- a/tests/inputs/test-imports/file4.less
+++ b/tests/inputs/test-imports/file4.less
@@ -1,0 +1,3 @@
+.dynamic {
+    color: @color;
+}

--- a/tests/outputs/import.css
+++ b/tests/outputs/import.css
@@ -46,6 +46,9 @@ body div.sad {
 pre {
   color: hello-from-file-3;
 }
+blockquote {
+  color: hello-from-imports-file; 
+}
 h2 {
   background: url("../images/logo.png") no-repeat;
 }

--- a/tests/outputs/import.css
+++ b/tests/outputs/import.css
@@ -47,7 +47,7 @@ pre {
   color: hello-from-file-3;
 }
 blockquote {
-  color: hello-from-imports-file; 
+  color: hello-from-imports-file;
 }
 h2 {
   background: url("../images/logo.png") no-repeat;

--- a/tests/outputs/import.css
+++ b/tests/outputs/import.css
@@ -52,3 +52,6 @@ blockquote {
 h2 {
   background: url("../images/logo.png") no-repeat;
 }
+.dynamic {
+  color: maroon;
+}


### PR DESCRIPTION
The problem this PR tries to fix was reported at splitbrain/dokuwiki#2260 - when trying to import files based on a variable, the Compiler class will throw an exception about the variable not being defined even though that not being the case.

The problem was introduced in leafo/lessphp#548 by @DannyvdSluijs which fixed leafo/lessphp#302

From what I understand, the PR changed the order of how two sets of properties are joined together, moving the variables behind the actual import resolution and thus triggering the "not defined" error. My patch basically duplicates the variables to have one set available before and one after the fact.

To avoid breaking leafo/lessphp#302 again, I applied (and fixed) the test proposed in leafo/lessphp#539

I assume my fix is not ideal and I do not know when the `$split` path is actually used and if my fix works properly there. Would be great if someone with more knowledge about the library could have a look.

This PR also contains a test for the problem fixed in a separate commit, which should make it easier to test possible alternative solutions. 