### PR TITLE
Use ob_end_clean to close output buffer properly

### DIFF
--- a/src/LesserPhp/Compiler.php
+++ b/src/LesserPhp/Compiler.php
@@ -1833,7 +1833,8 @@ class Compiler
 
         ob_start();
         $this->formatter->block($this->scope);
-        $out = ob_get_clean();
+        $out = ob_get_contents();
+        ob_end_clean();
         setlocale(LC_NUMERIC, $locale);
 
         return $out;


### PR DESCRIPTION
`ob_get_clean`> `ob_end_clean`.