### PR TITLE
PHP 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.6
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 sudo: false
 

--- a/src/LesserPhp/Compiler.php
+++ b/src/LesserPhp/Compiler.php
@@ -950,7 +950,7 @@ class Compiler
 
         // check for a rest
         $last = end($args);
-        if ($last[0] === "rest") {
+        if ($last !== false && $last[0] === "rest") {
             $rest = array_slice($orderedValues, count($args) - 1);
             $this->set($last[1], $this->reduce(["list", " ", $rest]));
         }
@@ -1790,7 +1790,7 @@ class Compiler
         $this->pushEnv($this->env);
         $parser = new Parser($this, __METHOD__);
         foreach ($args as $name => $strValue) {
-            if ($name{0} !== '@') {
+            if ($name[0] !== '@') {
                 $name = '@' . $name;
             }
             $parser->count = 0;

--- a/src/LesserPhp/Library/Assertions.php
+++ b/src/LesserPhp/Library/Assertions.php
@@ -17,7 +17,6 @@ use LesserPhp\Exception\GeneralException;
  */
 class Assertions
 {
-
     private $coerce;
 
     /**


### PR DESCRIPTION
This patch adds support for PHP7.4 by:

- add `7.4snapshot` to travis CI (they don't have the official PHP 7.4 release ready yet)
- fix: Array and string offset access syntax with curly braces is deprecated
  src/LesserPhp/Compiler.php:1793
- fix: Trying to access array offset on value of type bool
  src/LesserPhp/Compiler.php:953
- fix: styleci warning