### PR TITLE
support php8 and upgrade to phpunit 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.2
-  - 7.3
-  - 7.4snapshot
+  - 7.4
+  - 8.0
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,13 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.6",
-        "squizlabs/php_codesniffer": "2.8.*"
+        "phpunit/phpunit": "^9.3.0",
+        "squizlabs/php_codesniffer": "3.5.*"
     },
     "scripts": {
         "test": "vendor/bin/phpunit"
+    },
+    "require": {
+        "php": "^7.4 || ~8.0.0"
     }
 }

--- a/src/LesserPhp/Parser.php
+++ b/src/LesserPhp/Parser.php
@@ -1222,7 +1222,9 @@ nav ul {
                 if ($this->stringValue($str)) {
                     // escape parent selector, (yuck)
                     foreach ($str[2] as &$chunk) {
-                        $chunk = str_replace($this->lessc->getParentSelector(), '$&$', $chunk);
+                        if (is_string($chunk)) {
+                            $chunk = str_replace($this->lessc->getParentSelector(), '$&$', $chunk);
+                        }
                     }
 
                     $attrParts[] = $str;

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -19,7 +19,7 @@ class ApiTest extends PHPUnit\Framework\TestCase
      */
     private $less;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->less = new \LesserPhp\Compiler();
         $this->less->setImportDirs([__DIR__ . '/inputs/test-imports']);

--- a/tests/Base/CompilerTest.php
+++ b/tests/Base/CompilerTest.php
@@ -15,6 +15,7 @@ namespace Test\Base;
  * @package LesserPhp
  */
 use LesserPhp\Compiler;
+use LesserPhp\Exception\GeneralException;
 use LesserPhp\Formatter\FormatterInterface;
 
 class CompilerTest extends \PHPUnit\Framework\TestCase
@@ -57,12 +58,11 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @expectedException \LesserPhp\Exception\GeneralException
-     * @expectedExceptionMessage unknown value type: something
-     */
     public function testUnknownType()
     {
+        $this->expectException(GeneralException::class);
+        $this->expectExceptionMessage('unknown value type: something');
+
         $subject = new Compiler();
         $subject->compileValue(['something', 1]);
     }

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -19,7 +19,7 @@ class ErrorHandlingTest extends \PHPUnit\Framework\TestCase
      */
     private $less;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->less = new \LesserPhp\Compiler();
     }
@@ -31,120 +31,98 @@ class ErrorHandlingTest extends \PHPUnit\Framework\TestCase
         return $this->less->compile($source);
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage .parametric-mixin is undefined
-     */
     public function testRequiredParametersMissing()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('.parametric-mixin is undefined');
         $this->compile(
             '.parametric-mixin (@a, @b) { a: @a; b: @b; }',
             '.selector { .parametric-mixin(12px); }'
         );
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage .parametric-mixin is undefined
-     */
     public function testTooManyParameters()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('.parametric-mixin is undefined');
         $this->compile(
             '.parametric-mixin (@a, @b) { a: @a; b: @b; }',
             '.selector { .parametric-mixin(12px, 13px, 14px); }'
         );
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage unrecognised input
-     */
     public function testRequiredArgumentsMissing()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('unrecognised input');
         $this->compile('.selector { rule: e(); }');
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage variable @missing is undefined
-     */
     public function testVariableMissing()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('variable @missing is undefined');
         $this->compile('.selector { rule: @missing; }');
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage .missing-mixin is undefined
-     */
     public function testMixinMissing()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('.missing-mixin is undefined');
         $this->compile('.selector { .missing-mixin; }');
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage .flipped is undefined
-     */
     public function testGuardUnmatchedValue()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('.flipped is undefined');
         $this->compile(
             '.flipped(@x) when (@x =< 10) { rule: value; }',
             '.selector { .flipped(12); }'
         );
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage .colors-only is undefined
-     */
     public function testGuardUnmatchedType()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('.colors-only is undefined');
         $this->compile(
             '.colors-only(@x) when (iscolor(@x)) { rule: value; }',
             '.selector { .colors-only("string value"); }'
         );
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage    expecting at least 1 arguments, got 0
-     */
     public function testMinNoArguments()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('expecting at least 1 arguments, got 0');
         $this->compile(
             '.selector{ min: min(); }'
         );
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage    expecting at least 1 arguments, got 0
-     */
     public function testMaxNoArguments()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('expecting at least 1 arguments, got 0');
         $this->compile(
             '.selector{ max: max(); }'
         );
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage    Cannot convert % to px
-     */
     public function testMaxIncompatibleTypes()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cannot convert % to px');
         $this->compile(
             '.selector{ max: max( 10px, 5% ); }'
         );
     }
 
-    /**
-     * @expectedException        Exception
-     * @expectedExceptionMessage    Cannot convert px to s
-     */
     public function testConvertIncompatibleTypes()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cannot convert px to s');
         $this->compile(
             '.selector{ convert: convert( 10px, s ); }'
         );

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -36,7 +36,7 @@ class InputTest extends \PHPUnit\Framework\TestCase
 
     private $less;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->less = new \LesserPhp\Compiler();
         $this->less->setImportDirs(array_map(function ($path) {


### PR DESCRIPTION
For keeping up to date, upgrade and support only php7.4 and php8.0.
Also updated the tests to work with phpunit 9.3 which works with the latest PHP versions.

If any changes are required, please let me know. 
I am using https://github.com/mrclay/minify which requires this package.